### PR TITLE
feat: add initial postgres schema

### DIFF
--- a/ncfd/alembic/env.py
+++ b/ncfd/alembic/env.py
@@ -15,11 +15,17 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-# add your model's MetaData object here
-# for 'autogenerate' support
-# from myapp import mymodel
-# target_metadata = mymodel.Base.metadata
-target_metadata = None
+import sys
+from pathlib import Path
+
+# Ensure the ``src`` directory is on the path so that models can be imported.
+BASE_DIR = Path(__file__).resolve().parent.parent
+sys.path.append(str(BASE_DIR / "src"))
+
+from ncfd.db.models import Base  # noqa: E402
+
+# target metadata for autogeneration
+target_metadata = Base.metadata
 
 # other values from the config, defined by the needs of env.py,
 # can be acquired:

--- a/ncfd/alembic/versions/0001_initial.py
+++ b/ncfd/alembic/versions/0001_initial.py
@@ -1,0 +1,234 @@
+"""Initial database schema.
+
+Revision ID: 0001_initial
+Revises: 
+Create Date: 2024-08-16
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0001_initial"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:  # noqa: D401
+    """Create initial tables."""
+
+    op.create_table(
+        "companies",
+        sa.Column("company_id", sa.Integer(), primary_key=True),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("ticker", sa.String(length=10)),
+        sa.Column("cik", sa.String(length=10)),
+    )
+
+    op.create_table(
+        "assets",
+        sa.Column("asset_id", sa.Integer(), primary_key=True),
+        sa.Column("names_jsonb", postgresql.JSONB()),
+        sa.Column("modality", sa.Text()),
+        sa.Column("target", sa.Text()),
+        sa.Column("moa", sa.Text()),
+    )
+
+    op.create_table(
+        "trials",
+        sa.Column("trial_id", sa.Integer(), primary_key=True),
+        sa.Column("nct_id", sa.Text(), nullable=False, unique=True),
+        sa.Column("sponsor_text", sa.Text()),
+        sa.Column("sponsor_company_id", sa.Integer(), sa.ForeignKey("companies.company_id")),
+        sa.Column("phase", sa.Text()),
+        sa.Column("indication", sa.Text()),
+        sa.Column("is_pivotal", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("primary_endpoint_text", sa.Text()),
+        sa.Column("est_primary_completion_date", sa.Date()),
+        sa.Column("status", sa.Text()),
+        sa.Column("first_posted_date", sa.Date()),
+        sa.Column("last_update_posted_date", sa.Date()),
+        sa.Column("intervention_types", postgresql.ARRAY(sa.Text())),
+        sa.Column("last_seen_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("current_sha256", sa.String(length=64)),
+        sa.CheckConstraint("nct_id ~ '^NCT[0-9]{8}$'", name="chk_nct"),
+    )
+
+    op.create_table(
+        "trial_versions",
+        sa.Column("trial_version_id", sa.Integer(), primary_key=True),
+        sa.Column("trial_id", sa.Integer(), sa.ForeignKey("trials.trial_id", ondelete="CASCADE"), nullable=False),
+        sa.Column("captured_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("last_update_posted_date", sa.Date()),
+        sa.Column("raw_jsonb", postgresql.JSONB(), nullable=False),
+        sa.Column("sha256", sa.String(length=64), nullable=False),
+        sa.Column("primary_endpoint_text", sa.Text()),
+        sa.Column("sample_size", sa.Integer()),
+        sa.Column("analysis_plan_text", sa.Text()),
+        sa.Column("changes_jsonb", postgresql.JSONB()),
+        sa.UniqueConstraint("trial_id", "sha256", name="uq_trial_versions_trial_sha"),
+    )
+    op.create_index(
+        "idx_trial_versions_trial_time",
+        "trial_versions",
+        ["trial_id", "captured_at"],
+    )
+    op.create_index(
+        "idx_trial_versions_hash",
+        "trial_versions",
+        ["sha256"],
+    )
+
+    op.create_table(
+        "ctgov_history_versions",
+        sa.Column("trial_id", sa.Integer(), sa.ForeignKey("trials.trial_id", ondelete="CASCADE"), primary_key=True),
+        sa.Column("version_rank", sa.Integer(), primary_key=True),
+        sa.Column("submitted_date", sa.Date()),
+        sa.Column("url", sa.Text()),
+    )
+
+    op.create_table(
+        "ctgov_ingest_state",
+        sa.Column("id", sa.Boolean(), primary_key=True, server_default=sa.true()),
+        sa.Column("cursor_last_update_posted", sa.Date()),
+        sa.Column("last_run_at", sa.DateTime(timezone=True)),
+    )
+
+    op.create_table(
+        "ingest_runs",
+        sa.Column("run_id", sa.Integer(), primary_key=True),
+        sa.Column("source", sa.Text(), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False),
+        sa.Column("finished_at", sa.DateTime(timezone=True)),
+        sa.Column("since_date", sa.Date()),
+        sa.Column("until_date", sa.Date()),
+        sa.Column("total_returned", sa.Integer()),
+        sa.Column("total_processed", sa.Integer()),
+        sa.Column("notes", sa.Text()),
+    )
+
+    op.create_table(
+        "studies",
+        sa.Column("study_id", sa.Integer(), primary_key=True),
+        sa.Column("trial_id", sa.Integer(), sa.ForeignKey("trials.trial_id", ondelete="CASCADE"), nullable=False),
+        sa.Column("asset_id", sa.Integer(), sa.ForeignKey("assets.asset_id")),
+        sa.Column("doc_type", sa.Text()),
+        sa.Column("citation", sa.Text()),
+        sa.Column("year", sa.Integer()),
+        sa.Column("url", sa.Text()),
+        sa.Column("oa_status", sa.Text()),
+        sa.Column("extracted_jsonb", postgresql.JSONB()),
+        sa.Column("notes_md", sa.Text()),
+        sa.Column("coverage_level", sa.Integer()),
+    )
+
+    op.create_table(
+        "signals",
+        sa.Column("trial_id", sa.Integer(), sa.ForeignKey("trials.trial_id", ondelete="CASCADE"), primary_key=True),
+        sa.Column("s_id", sa.Text(), primary_key=True),
+        sa.Column("value", sa.Float()),
+        sa.Column("severity", sa.Text()),
+        sa.Column("evidence_span", sa.Text()),
+        sa.Column("source_study_id", sa.Integer(), sa.ForeignKey("studies.study_id")),
+    )
+
+    op.create_table(
+        "gates",
+        sa.Column("trial_id", sa.Integer(), sa.ForeignKey("trials.trial_id", ondelete="CASCADE"), primary_key=True),
+        sa.Column("g_id", sa.Text(), primary_key=True),
+        sa.Column("fired_bool", sa.Boolean(), nullable=False),
+        sa.Column("supporting_s_ids", postgresql.ARRAY(sa.Text())),
+        sa.Column("lr_used", sa.Float()),
+        sa.Column("rationale_text", sa.Text()),
+    )
+
+    op.create_table(
+        "scores",
+        sa.Column("trial_id", sa.Integer(), sa.ForeignKey("trials.trial_id", ondelete="CASCADE"), primary_key=True),
+        sa.Column("run_id", sa.Integer(), primary_key=True),
+        sa.Column("prior_pi", sa.Float()),
+        sa.Column("logit_prior", sa.Float()),
+        sa.Column("sum_log_lr", sa.Float()),
+        sa.Column("logit_post", sa.Float()),
+        sa.Column("p_fail", sa.Float()),
+    )
+
+    op.create_table(
+        "asset_ownership",
+        sa.Column("asset_id", sa.Integer(), sa.ForeignKey("assets.asset_id", ondelete="CASCADE"), primary_key=True),
+        sa.Column("company_id", sa.Integer(), sa.ForeignKey("companies.company_id", ondelete="CASCADE"), primary_key=True),
+        sa.Column("start_date", sa.Date(), primary_key=True),
+        sa.Column("end_date", sa.Date()),
+        sa.Column("source", sa.Text()),
+        sa.Column("evidence_url", sa.Text()),
+    )
+
+    op.create_table(
+        "patents",
+        sa.Column("patent_id", sa.Integer(), primary_key=True),
+        sa.Column("asset_id", sa.Integer(), sa.ForeignKey("assets.asset_id", ondelete="CASCADE")),
+        sa.Column("family_id", sa.Text()),
+        sa.Column("jurisdiction", sa.Text()),
+        sa.Column("number", sa.Text()),
+        sa.Column("earliest_priority_date", sa.Date()),
+        sa.Column("assignees", postgresql.ARRAY(sa.Text())),
+        sa.Column("inventors", postgresql.ARRAY(sa.Text())),
+        sa.Column("status", sa.Text()),
+    )
+
+    op.create_table(
+        "patent_assignments",
+        sa.Column("assignment_id", sa.Integer(), primary_key=True),
+        sa.Column("patent_id", sa.Integer(), sa.ForeignKey("patents.patent_id", ondelete="CASCADE"), nullable=False),
+        sa.Column("assignor", sa.Text()),
+        sa.Column("assignee", sa.Text()),
+        sa.Column("exec_date", sa.Date()),
+        sa.Column("type", sa.Text()),
+        sa.Column("source_url", sa.Text()),
+    )
+
+    op.create_table(
+        "labels",
+        sa.Column("trial_id", sa.Integer(), sa.ForeignKey("trials.trial_id", ondelete="CASCADE"), primary_key=True),
+        sa.Column("event_date", sa.Date(), primary_key=True),
+        sa.Column("primary_outcome_success_bool", sa.Boolean()),
+        sa.Column("price_move_5d", sa.Float()),
+        sa.Column("label_source_url", sa.Text()),
+    )
+
+    op.create_table(
+        "catalysts",
+        sa.Column("trial_id", sa.Integer(), sa.ForeignKey("trials.trial_id", ondelete="CASCADE"), primary_key=True),
+        sa.Column("window_start", sa.Date(), primary_key=True),
+        sa.Column("window_end", sa.Date()),
+        sa.Column("certainty", sa.Float()),
+        sa.Column("sources", postgresql.ARRAY(sa.Text())),
+    )
+
+
+def downgrade() -> None:  # noqa: D401
+    """Drop all tables."""
+
+    op.drop_table("catalysts")
+    op.drop_table("labels")
+    op.drop_table("patent_assignments")
+    op.drop_table("patents")
+    op.drop_table("asset_ownership")
+    op.drop_table("scores")
+    op.drop_table("gates")
+    op.drop_table("signals")
+    op.drop_table("studies")
+    op.drop_table("ingest_runs")
+    op.drop_table("ctgov_ingest_state")
+    op.drop_table("ctgov_history_versions")
+    op.drop_index("idx_trial_versions_hash", table_name="trial_versions")
+    op.drop_index("idx_trial_versions_trial_time", table_name="trial_versions")
+    op.drop_table("trial_versions")
+    op.drop_table("trials")
+    op.drop_table("assets")
+    op.drop_table("companies")
+

--- a/ncfd/scripts/db_migrate.py
+++ b/ncfd/scripts/db_migrate.py
@@ -1,0 +1,20 @@
+"""Helper script to run Alembic migrations."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from alembic import command
+from alembic.config import Config
+
+
+def upgrade(revision: str = "head") -> None:
+    """Upgrade the database to ``revision`` (defaults to ``head``)."""
+
+    cfg = Config(str(Path(__file__).resolve().parent.parent / "alembic.ini"))
+    command.upgrade(cfg, revision)
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience entry point
+    upgrade()
+

--- a/ncfd/src/ncfd/db/__init__.py
+++ b/ncfd/src/ncfd/db/__init__.py
@@ -1,0 +1,15 @@
+"""Database module exposing models and helpers."""
+
+from . import models
+from .models import *  # noqa: F401,F403
+from .session import Base, SessionLocal, create_all, get_engine, session_scope
+
+__all__ = [
+    *models.__all__,  # type: ignore[attr-defined]
+    "Base",
+    "SessionLocal",
+    "create_all",
+    "get_engine",
+    "session_scope",
+]
+

--- a/ncfd/src/ncfd/db/models.py
+++ b/ncfd/src/ncfd/db/models.py
@@ -1,0 +1,287 @@
+"""Database models for core trial data."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import (
+    ARRAY,
+    Boolean,
+    CheckConstraint,
+    Column,
+    Date,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    Index,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import declarative_base
+
+
+Base = declarative_base()
+
+
+# --- Reference tables -------------------------------------------------------
+
+
+class Company(Base):
+    """Public company issuing a security."""
+
+    __tablename__ = "companies"
+
+    company_id = Column(Integer, primary_key=True)
+    name = Column(Text, nullable=False)
+    ticker = Column(String(10))
+    cik = Column(String(10))
+
+
+class Asset(Base):
+    """Therapeutic asset tracked across trials."""
+
+    __tablename__ = "assets"
+
+    asset_id = Column(Integer, primary_key=True)
+    names_jsonb = Column(JSONB)
+    modality = Column(Text)
+    target = Column(Text)
+    moa = Column(Text)
+
+
+class Trial(Base):
+    """Normalized clinical trial record."""
+
+    __tablename__ = "trials"
+
+    trial_id = Column(Integer, primary_key=True)
+    nct_id = Column(Text, nullable=False, unique=True)
+    sponsor_text = Column(Text)
+    sponsor_company_id = Column(Integer, ForeignKey("companies.company_id"))
+    phase = Column(Text)
+    indication = Column(Text)
+    is_pivotal = Column(Boolean, nullable=False, default=False)
+    primary_endpoint_text = Column(Text)
+    est_primary_completion_date = Column(Date)
+    status = Column(Text)
+    first_posted_date = Column(Date)
+    last_update_posted_date = Column(Date)
+    intervention_types = Column(ARRAY(Text))
+    last_seen_at = Column(
+        DateTime(timezone=True), nullable=False, default=datetime.utcnow
+    )
+    current_sha256 = Column(String(64))
+
+    __table_args__ = (
+        CheckConstraint("nct_id ~ '^NCT[0-9]{8}$'", name="chk_nct"),
+    )
+
+
+class TrialVersion(Base):
+    """Forward-captured snapshot of a trial record."""
+
+    __tablename__ = "trial_versions"
+
+    trial_version_id = Column(Integer, primary_key=True)
+    trial_id = Column(Integer, ForeignKey("trials.trial_id", ondelete="CASCADE"), nullable=False)
+    captured_at = Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow)
+    last_update_posted_date = Column(Date)
+    raw_jsonb = Column(JSONB, nullable=False)
+    sha256 = Column(String(64), nullable=False)
+    primary_endpoint_text = Column(Text)
+    sample_size = Column(Integer)
+    analysis_plan_text = Column(Text)
+    changes_jsonb = Column(JSONB)
+
+    __table_args__ = (
+        UniqueConstraint("trial_id", "sha256", name="uq_trial_versions_trial_sha"),
+        Index("idx_trial_versions_trial_time", "trial_id", "captured_at"),
+        Index("idx_trial_versions_hash", "sha256"),
+    )
+
+
+class CTGovHistoryVersion(Base):
+    """Metadata scraped from the ClinicalTrials.gov Record History page."""
+
+    __tablename__ = "ctgov_history_versions"
+
+    trial_id = Column(Integer, ForeignKey("trials.trial_id", ondelete="CASCADE"), primary_key=True)
+    version_rank = Column(Integer, primary_key=True)
+    submitted_date = Column(Date)
+    url = Column(Text)
+
+
+class CTGovIngestState(Base):
+    """Singleton table tracking cursor position for CT.gov ingestion."""
+
+    __tablename__ = "ctgov_ingest_state"
+
+    id = Column(Boolean, primary_key=True, default=True)
+    cursor_last_update_posted = Column(Date)
+    last_run_at = Column(DateTime(timezone=True))
+
+
+class IngestRun(Base):
+    """Audit log for ingestion runs."""
+
+    __tablename__ = "ingest_runs"
+
+    run_id = Column(Integer, primary_key=True)
+    source = Column(Text, nullable=False)
+    started_at = Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow)
+    finished_at = Column(DateTime(timezone=True))
+    since_date = Column(Date)
+    until_date = Column(Date)
+    total_returned = Column(Integer)
+    total_processed = Column(Integer)
+    notes = Column(Text)
+
+
+class Study(Base):
+    """External document providing evidence about a trial."""
+
+    __tablename__ = "studies"
+
+    study_id = Column(Integer, primary_key=True)
+    trial_id = Column(Integer, ForeignKey("trials.trial_id", ondelete="CASCADE"), nullable=False)
+    asset_id = Column(Integer, ForeignKey("assets.asset_id"))
+    doc_type = Column(Text)  # e.g. PR, Abstract, Paper
+    citation = Column(Text)
+    year = Column(Integer)
+    url = Column(Text)
+    oa_status = Column(Text)
+    extracted_jsonb = Column(JSONB)
+    notes_md = Column(Text)
+    coverage_level = Column(Integer)
+
+
+class Signal(Base):
+    """Primitive signal extracted from a study."""
+
+    __tablename__ = "signals"
+
+    trial_id = Column(Integer, ForeignKey("trials.trial_id", ondelete="CASCADE"), primary_key=True)
+    s_id = Column(Text, primary_key=True)
+    value = Column(Float)
+    severity = Column(Text)
+    evidence_span = Column(Text)
+    source_study_id = Column(Integer, ForeignKey("studies.study_id"))
+
+
+class Gate(Base):
+    """Composite gate built from multiple signals."""
+
+    __tablename__ = "gates"
+
+    trial_id = Column(Integer, ForeignKey("trials.trial_id", ondelete="CASCADE"), primary_key=True)
+    g_id = Column(Text, primary_key=True)
+    fired_bool = Column(Boolean, nullable=False)
+    supporting_s_ids = Column(ARRAY(Text))
+    lr_used = Column(Float)
+    rationale_text = Column(Text)
+
+
+class Score(Base):
+    """Posterior failure probability for a trial."""
+
+    __tablename__ = "scores"
+
+    trial_id = Column(Integer, ForeignKey("trials.trial_id", ondelete="CASCADE"), primary_key=True)
+    run_id = Column(Integer, primary_key=True)
+    prior_pi = Column(Float)
+    logit_prior = Column(Float)
+    sum_log_lr = Column(Float)
+    logit_post = Column(Float)
+    p_fail = Column(Float)
+
+
+class AssetOwnership(Base):
+    """Ownership periods of an asset by a company."""
+
+    __tablename__ = "asset_ownership"
+
+    asset_id = Column(Integer, ForeignKey("assets.asset_id", ondelete="CASCADE"), primary_key=True)
+    company_id = Column(Integer, ForeignKey("companies.company_id", ondelete="CASCADE"), primary_key=True)
+    start_date = Column(Date, primary_key=True)
+    end_date = Column(Date)
+    source = Column(Text)
+    evidence_url = Column(Text)
+
+
+class Patent(Base):
+    """Patent associated with an asset."""
+
+    __tablename__ = "patents"
+
+    patent_id = Column(Integer, primary_key=True)
+    asset_id = Column(Integer, ForeignKey("assets.asset_id", ondelete="CASCADE"))
+    family_id = Column(Text)
+    jurisdiction = Column(Text)
+    number = Column(Text)
+    earliest_priority_date = Column(Date)
+    assignees = Column(ARRAY(Text))
+    inventors = Column(ARRAY(Text))
+    status = Column(Text)
+
+
+class PatentAssignment(Base):
+    """Assignment record for a patent."""
+
+    __tablename__ = "patent_assignments"
+
+    assignment_id = Column(Integer, primary_key=True)
+    patent_id = Column(Integer, ForeignKey("patents.patent_id", ondelete="CASCADE"), nullable=False)
+    assignor = Column(Text)
+    assignee = Column(Text)
+    exec_date = Column(Date)
+    type = Column(Text)
+    source_url = Column(Text)
+
+
+class Label(Base):
+    """Outcome label for a trial readout."""
+
+    __tablename__ = "labels"
+
+    trial_id = Column(Integer, ForeignKey("trials.trial_id", ondelete="CASCADE"), primary_key=True)
+    event_date = Column(Date, primary_key=True)
+    primary_outcome_success_bool = Column(Boolean)
+    price_move_5d = Column(Float)
+    label_source_url = Column(Text)
+
+
+class Catalyst(Base):
+    """Important upcoming trial catalyst windows."""
+
+    __tablename__ = "catalysts"
+
+    trial_id = Column(Integer, ForeignKey("trials.trial_id", ondelete="CASCADE"), primary_key=True)
+    window_start = Column(Date, primary_key=True)
+    window_end = Column(Date)
+    certainty = Column(Float)
+    sources = Column(ARRAY(Text))
+
+
+__all__ = [
+    "Base",
+    "Company",
+    "Asset",
+    "Trial",
+    "TrialVersion",
+    "CTGovHistoryVersion",
+    "CTGovIngestState",
+    "IngestRun",
+    "Study",
+    "Signal",
+    "Gate",
+    "Score",
+    "AssetOwnership",
+    "Patent",
+    "PatentAssignment",
+    "Label",
+    "Catalyst",
+]
+

--- a/ncfd/src/ncfd/db/session.py
+++ b/ncfd/src/ncfd/db/session.py
@@ -1,0 +1,57 @@
+"""Database session helpers."""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from typing import Iterator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from .models import Base
+
+
+def get_engine(url: str | None = None):
+    """Return a SQLAlchemy engine.
+
+    Parameters
+    ----------
+    url:
+        Database URL. If ``None`` the ``DATABASE_URL`` environment variable is
+        used. When neither is provided an in-memory SQLite database is used
+        which is suitable for tests.
+    """
+
+    return create_engine(url or os.getenv("DATABASE_URL", "sqlite+pysqlite:///:memory:"))
+
+
+def create_all(url: str | None = None) -> None:
+    """Create all tables defined in :mod:`ncfd.db.models`."""
+
+    engine = get_engine(url)
+    Base.metadata.create_all(engine)
+
+
+SessionLocal = sessionmaker(autocommit=False, autoflush=False)
+
+
+@contextmanager
+def session_scope(url: str | None = None) -> Iterator[Session]:
+    """Provide a transactional scope around a series of operations."""
+
+    engine = get_engine(url)
+    SessionLocal.configure(bind=engine)
+    session: Session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+__all__ = ["get_engine", "create_all", "session_scope", "SessionLocal", "Base"]
+


### PR DESCRIPTION
## Summary
- define SQLAlchemy models for trials, versions, assets, and related objects
- provide session helpers and Alembic migration to create schema
- add migration utility script

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a04b53e7bc8332a3daaf76e2c7c6a3