### PR TITLE
Handle ignore sponsor patterns and fix review loop SQL

### DIFF
--- a/ncfd/alembic/versions/7f3bc4a1d9e2_resolver_ignore_sponsor_table.py
+++ b/ncfd/alembic/versions/7f3bc4a1d9e2_resolver_ignore_sponsor_table.py
@@ -1,0 +1,50 @@
+"""resolver_ignore_sponsor table
+
+Revision ID: 7f3bc4a1d9e2
+Revises: e4587e9c596d
+Create Date: 2025-08-19 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "7f3bc4a1d9e2"
+down_revision: Union[str, Sequence[str], None] = "e4587e9c596d"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "resolver_ignore_sponsor",
+        sa.Column("pattern", sa.Text(), primary_key=True),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+    op.execute(
+        """
+        INSERT INTO resolver_ignore_sponsor (pattern, reason) VALUES
+        ('NCI', 'government'),
+        ('NIH', 'government'),
+        ('VA', 'government'),
+        ('Department of Veterans Affairs', 'government'),
+        ('Department of Defense', 'government'),
+        ('DoD', 'government'),
+        ('ECOG-ACRIN', 'coop group'),
+        ('SWOG', 'coop group'),
+        ('NRG', 'coop group'),
+        ('Alliance', 'coop group')
+        ON CONFLICT (pattern) DO NOTHING;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("resolver_ignore_sponsor")

--- a/ncfd/review-loop.sh
+++ b/ncfd/review-loop.sh
@@ -135,10 +135,10 @@ accept_item() {
   read -r RUN_ID NCT_ID SPONSOR <<<"$(meta_of "$rq_id")"
 
   # Update trial + remove from queue
-  psql "$PSQL_DSN" -v cid="$company_id" -v nct="$NCT_ID" -v rq="$rq_id" -c "
+  psql "$PSQL_DSN" -c "
     BEGIN;
-      UPDATE trials SET sponsor_company_id = :cid WHERE nct_id = :'nct';
-      DELETE FROM resolver_review_queue WHERE rq_id = :rq;
+      UPDATE trials SET sponsor_company_id = $company_id WHERE nct_id = '$NCT_ID';
+      DELETE FROM resolver_review_queue WHERE rq_id = $rq_id;
     COMMIT;
   " >/dev/null
 }


### PR DESCRIPTION
## Summary
- Create `resolver_ignore_sponsor` table and seed common government/cooperative-group patterns
- Fix review-loop `accept_item` SQL substitution to avoid psql `:var` errors

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install sqlalchemy` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68a3bfd69dd083328d51089c5ab698fc